### PR TITLE
Temporarily remove the youtube API request

### DIFF
--- a/src/pages/HomePage/components/Websites/Websites.tsx
+++ b/src/pages/HomePage/components/Websites/Websites.tsx
@@ -1,31 +1,31 @@
 import React from 'react';
 import { orderBy } from 'lodash';
 import { gql } from '@apollo/client';
-import {
-  useDispatch,
-  // useSelector
-} from 'react-redux';
+// import {
+//   useDispatch,
+//   // useSelector
+// } from 'react-redux';
 import { logger } from 'services';
 import mirrorApi from 'api/mirrorApi';
 import dayjs from 'dayjs';
 import { arweave } from '../../../../helpers/arweave/arweave';
 import { arweaveClient } from '../../../../helpers/arweave/arweaveClient';
-import { GOOGLE_API_KEY } from '../../../../constants/envVars';
+// import { GOOGLE_API_KEY } from '../../../../constants/envVars';
 
 import { NewsTileTitle } from '../NewsTileTitle';
 import { NewsCard } from '../../../../components/NewsCard';
 import { TagButton, TileContainer } from '../../../../components/UILib';
 
-import {
-  setVideos,
-  // selectVideos,
-  // selectArticles,
-} from '../../../../store/news';
+// import {
+//   setVideos,
+//   // selectVideos,
+//   // selectArticles,
+// } from '../../../../store/news';
 
 import { NEWS_TYPES } from '../../../../store/types';
-import { VideoResponse } from '../../../../store/news/types';
+// import { VideoResponse } from '../../../../store/news/types';
 
-import { request } from '../../../../utils/apiUtils';
+// import { request } from '../../../../utils/apiUtils';
 
 import s from './Websites.module.scss';
 
@@ -68,7 +68,7 @@ interface WebsitesProps {
   className?: string;
 }
 
-const YOUTUBE_API_URL = `https://www.googleapis.com/youtube/v3/search/?part=snippet&channelId=UCoNxg5l_2Gujke_Spm41F8Q&videoCaption=any&key=${GOOGLE_API_KEY}`;
+// const YOUTUBE_API_URL = `https://www.googleapis.com/youtube/v3/search/?part=snippet&channelId=UCoNxg5l_2Gujke_Spm41F8Q&videoCaption=any&key=${GOOGLE_API_KEY}`;
 
 const ARTICLES_QUERY = gql`
   query {
@@ -93,18 +93,18 @@ const ARTICLES_QUERY = gql`
 `;
 
 export const Websites: React.FC<WebsitesProps> = ({ className }) => {
-  const dispatch = useDispatch();
+  // const dispatch = useDispatch();
 
   const [section, setSection] = React.useState(FILTERS_CONFIG[0].type);
   const [transactionList, setTransactionList] = React.useState<Article[]>([]);
 
-  React.useEffect(() => {
-    request<VideoResponse>(YOUTUBE_API_URL).then((data) => {
-      if (data) {
-        dispatch(setVideos(data));
-      }
-    });
-  }, [dispatch]);
+  // React.useEffect(() => {
+  //   request<VideoResponse>(YOUTUBE_API_URL).then((data) => {
+  //     if (data) {
+  //       dispatch(setVideos(data));
+  //     }
+  //   });
+  // }, [dispatch]);
 
   const getArticles = async () => {
     // Fetch all the articles with the arweave graphql endpoint


### PR DESCRIPTION
# Project: New Order DAO App Frontend

## Motivation and Context

Why is this change required? What problem does it solve?
- It breaks the function to fetch data from the arweave graphql api

## Description

Describe your changes in detail.
- Commented out the `useEffect` request on the youtube api for videos

### Related Issues

Resolves #26 

### How Has This Been Tested?

Please describe in detail how you tested your changes.
- Checked if passes the request and continues to get the articles from mirror

### Screenshots/Video (if appropriate):

If this PR covers a UI or workflow change, an image displaying the change should accompany the PR
  

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.