### PR TITLE
Change all the APY labels to APR

### DIFF
--- a/src/pages/InvestPage/components/ActiveDepositsTab/components/Deposits/Deposits.tsx
+++ b/src/pages/InvestPage/components/ActiveDepositsTab/components/Deposits/Deposits.tsx
@@ -318,7 +318,7 @@ export const Deposits: React.FC<ActiveDepositsProps> = () => {
         },
       },
       {
-        Header: 'Strategy APY',
+        Header: 'APR',
         cellClassName: s.narrowColumns,
         accessor: 'strategyAPY',
         Cell: ({ cell }: CellProps<{ value: number }>) => {

--- a/src/pages/InvestPage/components/DepositInfo/DepositInfo.tsx
+++ b/src/pages/InvestPage/components/DepositInfo/DepositInfo.tsx
@@ -279,7 +279,7 @@ export const DepositInfo: React.FC<DepositInfoProps> = (props) => {
         <div className={s.tile}>
           <div className={s.tilePart}>
             <div className={s.currency}>NEWO SINGLE-SIDE</div>
-            <div className={s.strategy}>APY</div>
+            <div className={s.strategy}>APR</div>
             <div className={s.percentValue}>
               {apy === 0 ? (
                 <span>NaN</span>
@@ -362,7 +362,7 @@ export const DepositInfo: React.FC<DepositInfoProps> = (props) => {
         <div className={s.tile}>
           <div className={s.tilePart}>
             <div className={s.currency}>SUSHI LP - NEWO/USDC</div>
-            <div className={s.strategy}>APY</div>
+            <div className={s.strategy}>APR</div>
             <div className={s.percentValue}>
               {slpVaultApy === 0 ? (
                 <span>NaN</span>


### PR DESCRIPTION
# Project: New Order DAO App Frontend

## Motivation and Context

Why is this change required? What problem does it solve?

- Because people get confused about the rewards they're getting, upon checking with the team, It's APR and not APY

## Description

Describe your changes in detail.

- Changed any "APY" I can find that shows on the app
- Didn't changed variables tho. because it might break

### Related Issues

Resolves #34 

### How Has This Been Tested?

Please describe in detail how you tested your changes.

- Checked every page that has APY and see if it's APR

### Screenshots/Video (if appropriate):

If this PR covers a UI or workflow change, an image displaying the change should accompany the PR
 
![image](https://user-images.githubusercontent.com/46964393/148563434-a7c73f87-a255-4956-9055-58a7d3aea068.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.